### PR TITLE
Fix edge case with 0.5

### DIFF
--- a/content/data/tables/a_ui_functions-sct.tbm
+++ b/content/data/tables/a_ui_functions-sct.tbm
@@ -109,7 +109,7 @@ function ScpuiSystem:getFontPixelSize(val)
 	end
 	
 	if not val then
-		val = convert(ScpuiOptionValues.Font_Adjustment) or 0.5
+		val = convert(ScpuiOptionValues.Font_Adjustment or 0.5)
 	else
 		val = convert(val)
 	end


### PR DESCRIPTION
this ensures that all values are fully rounded, otherwise there might be a half value that does not play nice with the whole rounded font numbers